### PR TITLE
Adds the ability to save variable names when minifying

### DIFF
--- a/AspNetBundling/ScriptWithSourceMapBundle.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundle.cs
@@ -15,10 +15,23 @@ namespace AspNetBundling
         }
 
         public ScriptWithSourceMapBundle(string virtualPath, string cdnPath)
+            : this(virtualPath, cdnPath, false)
+        {
+
+        }
+        
+        /// <param name="preserveVariablesName">Preserve variables names in scripts </param>
+        public ScriptWithSourceMapBundle(string virtualPath, bool preserveVariablesName)
+            : this(virtualPath, null, preserveVariablesName)
+        {
+
+        }
+
+        /// <param name="preserveVariablesName">Preserve variables names in scripts </param>
+        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool preserveVariablesName)
             : base(virtualPath, cdnPath, new IBundleTransform[] { })
         {
-            this.Builder = new ScriptWithSourceMapBundleBuilder();
-            //base.ConcatenationToken = ";" + Environment.NewLine;
+            this.Builder = new ScriptWithSourceMapBundleBuilder(){preserveVariablesNames = preserveVariablesName};
         }
 
         // Don't allow the transforms constructor as we wouldn't be able to generated source mapping if it gets transformed

--- a/AspNetBundling/ScriptWithSourceMapBundle.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundle.cs
@@ -8,30 +8,48 @@ namespace AspNetBundling
     /// </summary>
     public class ScriptWithSourceMapBundle : Bundle
     {
+        /// <summary>
+        /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path for the bundle.
+        /// </summary>
         public ScriptWithSourceMapBundle(string virtualPath)
-            : this(virtualPath, null)
+            : this(virtualPath, null, false)
         {
 
         }
 
+        /// <summary>
+        /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path and a cdnPath for the bundle.
+        /// </summary>
         public ScriptWithSourceMapBundle(string virtualPath, string cdnPath)
             : this(virtualPath, cdnPath, false)
         {
 
         }
         
-        /// <param name="preserveVariablesName">Preserve variables names in scripts </param>
-        public ScriptWithSourceMapBundle(string virtualPath, bool preserveVariablesName)
-            : this(virtualPath, null, preserveVariablesName)
+        /// <summary>
+        /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path 
+        /// and allows code minification to be toggled.
+        /// </summary>
+        /// <param name="minifyCode">Preserve variables names in scripts </param>
+        public ScriptWithSourceMapBundle(string virtualPath, bool minifyCode)
+            : this(virtualPath, null, minifyCode)
         {
 
         }
 
-        /// <param name="preserveVariablesName">Preserve variables names in scripts </param>
-        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool preserveVariablesName)
+        /// <summary>
+        /// Initializes a new instance of the ScriptWithSourceMapBundle that takes a virtual path, a cdnPath
+        /// and allows code minifcation to be toggled.
+        /// </summary>
+        /// <param name="virtualPath"></param>
+        /// <param name="minifyCode">
+        /// Minify code or not. Set to false to preserve variable names when needed (e.g. Angular),
+        /// however the source code won't be minified to the full extent, only whitespace will be removed.
+        /// </param>
+        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool minifyCode)
             : base(virtualPath, cdnPath, new IBundleTransform[] { })
         {
-            this.Builder = new ScriptWithSourceMapBundleBuilder(){preserveVariablesNames = preserveVariablesName};
+            this.Builder = new ScriptWithSourceMapBundleBuilder() { minifyCode = minifyCode };
         }
 
         // Don't allow the transforms constructor as we wouldn't be able to generated source mapping if it gets transformed

--- a/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
@@ -54,7 +54,7 @@ namespace AspNetBundling
                         PreserveImportantComments = false,
                         SymbolsMap = sourceMap,
                         TermSemicolons = true,
-                        MinifyCode = preserveVariablesNames
+                        MinifyCode = minifyCode
                     };
 
                     sourceMap.StartPackage(sourcePath, mapPath);
@@ -174,6 +174,6 @@ namespace AspNetBundling
 
         const string sourceMappingDisabledMsg = "/* Source mapping won't work properly right now, sorry! The debugger is attached and the following bug exists in AjaxMin: https://ajaxmin.codeplex.com/workitem/21834 */";
 
-        internal bool preserveVariablesNames = false;
+        internal bool minifyCode = false;
     }
 }

--- a/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
@@ -53,7 +53,8 @@ namespace AspNetBundling
                         EvalTreatment = EvalTreatment.MakeImmediateSafe,
                         PreserveImportantComments = false,
                         SymbolsMap = sourceMap,
-                        TermSemicolons = true
+                        TermSemicolons = true,
+                        MinifyCode = preserveVariablesNames
                     };
 
                     sourceMap.StartPackage(sourcePath, mapPath);
@@ -172,5 +173,7 @@ namespace AspNetBundling
         }
 
         const string sourceMappingDisabledMsg = "/* Source mapping won't work properly right now, sorry! The debugger is attached and the following bug exists in AjaxMin: https://ajaxmin.codeplex.com/workitem/21834 */";
+
+        internal bool preserveVariablesNames = false;
     }
 }


### PR DESCRIPTION
Sometimes names of variables need to keep (for example, when used angularjs objects). This has add to constructor an param to protect variable names.