### PR TITLE
Added verbosity of exceptions during minification

### DIFF
--- a/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
@@ -90,7 +90,7 @@ namespace AspNetBundling
                 string bundlePrefix = "[Bundle '" + bundle.Path + "']";
                 Trace.TraceInformation(bundlePrefix + " exception message: " + ex.Message);
                 
-                if (!string.IsNullOrEmpty(ex.InnerException?.Message))
+                if (ex.InnerException != null && !string.IsNullOrEmpty(ex.InnerException.Message))
                 {
                     Trace.TraceInformation(bundlePrefix + " inner exception message: " + ex.InnerException.Message);
                 }

--- a/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
@@ -84,7 +84,20 @@ namespace AspNetBundling
             }
             catch (Exception ex)
             {
-                Trace.TraceWarning("An exception occurred trying to build bundle contents for bundle with virtual path: " + bundle.Path + ". See Exception details.", ex, typeof(ScriptWithSourceMapBundleBuilder));
+                // only Trace the fact that an exception occurred to the Warning output, but use Informational tracing for added detail for diagnosis
+                Trace.TraceWarning("An exception occurred trying to build bundle contents for bundle with virtual path: " + bundle.Path + ". See Exception details in Information.");
+                
+                string bundlePrefix = "[Bundle '" + bundle.Path + "']";
+                Trace.TraceInformation(bundlePrefix + " exception message: " + ex.Message);
+                
+                if (!string.IsNullOrEmpty(ex.InnerException?.Message))
+                {
+                    Trace.TraceInformation(bundlePrefix + " inner exception message: " + ex.InnerException.Message);
+                }
+                
+                Trace.TraceInformation(bundlePrefix + " source: " + ex.Source);
+                Trace.TraceInformation(bundlePrefix + " stack trace: " + ex.StackTrace);
+                
                 return GenerateGenericErrorsContent(contentConcatedString);
             }
         }


### PR DESCRIPTION
Converted the Trace.TraceWarning call to a top-level message that something wrong happened and added Trace.TraceInformational calls for added verbosity in debugging issues.