### PR TITLE
Add ability to define custom source map extension

### DIFF
--- a/AspNetBundling.TestWebsite/App_Start/BundleConfig.cs
+++ b/AspNetBundling.TestWebsite/App_Start/BundleConfig.cs
@@ -1,5 +1,4 @@
-﻿using System.Web;
-using System.Web.Optimization;
+﻿using System.Web.Optimization;
 
 namespace AspNetBundling.TestWebsite
 {
@@ -8,7 +7,7 @@ namespace AspNetBundling.TestWebsite
         // For more information on bundling, visit http://go.microsoft.com/fwlink/?LinkId=301862
         public static void RegisterBundles(BundleCollection bundles)
         {
-            bundles.Add(new ScriptWithSourceMapBundle("~/bundles/jquery")
+            bundles.Add(new ScriptWithSourceMapBundle("~/bundles/jquery", null, true, true, ".bundle")
                 .Include("~/Scripts/jquery-{version}.js"));
 
             bundles.Add(new ScriptWithSourceMapBundle("~/bundles/jquery-no-important-comments", null, true, false)

--- a/AspNetBundling.TestWebsite/Web.config
+++ b/AspNetBundling.TestWebsite/Web.config
@@ -26,6 +26,9 @@
     <modules>
       <remove name="FormsAuthenticationModule"/>
     </modules>
+    <handlers>
+      <add name="scriptBundle" verb="*" path="*.bundle" type="System.Web.Optimization.BundleHandler, System.Web.Optimization" preCondition="managedHandler" />
+    </handlers>
     <staticContent>
       <remove fileExtension=".map"/>
       <mimeMap fileExtension=".map" mimeType="application/json"/>

--- a/AspNetBundling/ScriptWithSourceMapBundle.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundle.cs
@@ -12,7 +12,7 @@ namespace AspNetBundling
         /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path for the bundle.
         /// </summary>
         public ScriptWithSourceMapBundle(string virtualPath)
-            : this(virtualPath, null, false, true)
+            : this(virtualPath, null, false, true, DefaultSourceMapExtension)
         {
 
         }
@@ -21,25 +21,36 @@ namespace AspNetBundling
         /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path and a cdnPath for the bundle.
         /// </summary>
         public ScriptWithSourceMapBundle(string virtualPath, string cdnPath)
-            : this(virtualPath, cdnPath, true, true)
+            : this(virtualPath, cdnPath, true, true, DefaultSourceMapExtension)
         {
 
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the ScriptWithSourceMapBundle class that takes a virtual path 
         /// and allows code minification to be toggled.
         /// </summary>
         /// <param name="minifyCode">Preserve variables names in scripts </param>
         public ScriptWithSourceMapBundle(string virtualPath, bool minifyCode)
-            : this(virtualPath, null, minifyCode, true)
+            : this(virtualPath, null, minifyCode, true, DefaultSourceMapExtension)
         {
 
         }
 
         /// <summary>
-        /// Initializes a new instance of the ScriptWithSourceMapBundle that takes a virtual path, a cdnPath
-        /// and allows code minifcation to be toggled.
+        /// Initializes a new instance of the ScriptWithSourceMapBundle that takes a virtual path, a cdnPath,
+        /// allows code minification to be toggled and preservation of important comments.
+        /// </summary>
+        /// <param name="preserveImportantComments">Toggle to preserve important comments when needed (e.g. legal requirement for a library)</param>
+        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool minifyCode, bool preserveImportantComments)
+          : this(virtualPath, null, minifyCode, preserveImportantComments, DefaultSourceMapExtension)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ScriptWithSourceMapBundle that takes a virtual path, a cdnPath,
+        /// allows code minification to be toggled, preservation of important comments, and custom bundle extension.
         /// </summary>
         /// <param name="virtualPath">Virtual path for the bundle to be accessible on.</param>
         /// <param name="cdnPath">CDN path for the bundle if available on a CDN too.</param>
@@ -48,15 +59,23 @@ namespace AspNetBundling
         /// however the source code won't be minified to the full extent, only whitespace will be removed.
         /// </param>
         /// <param name="preserveImportantComments">Toggle to preserve important comments when needed (e.g. legal requirement for a library)</param>
-        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool minifyCode, bool preserveImportantComments)
+        /// <param name="sourceMapExtension">
+        /// Adds the desired extension to the source map, in case this isn't set, "map" will be appended at the end of the current bundle name.
+        /// In case you want to use custom extension you need to add a custom handler in your web.config file for the source map to work.
+        /// Please check https://stackoverflow.com/a/12931522
+        /// </param>
+        public ScriptWithSourceMapBundle(string virtualPath, string cdnPath, bool minifyCode, bool preserveImportantComments, string sourceMapExtension)
             : base(virtualPath, cdnPath, new IBundleTransform[] { })
         {
             this.Builder = new ScriptWithSourceMapBundleBuilder()
             {
                 minifyCode = minifyCode,
-                preserveImportantComments = preserveImportantComments
+                preserveImportantComments = preserveImportantComments,
+                sourceMapExtension = sourceMapExtension
             };
         }
+
+        internal const string DefaultSourceMapExtension = "map";
 
         // Don't allow the transforms constructor as we wouldn't be able to generated source mapping if it gets transformed
     }

--- a/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
+++ b/AspNetBundling/ScriptWithSourceMapBundleBuilder.cs
@@ -1,5 +1,4 @@
 extern alias AjaxMin;
-using AjaxMin::Microsoft.Ajax.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Web;
 using System.Web.Optimization;
+using AjaxMin::Microsoft.Ajax.Utilities;
 
 namespace AspNetBundling
 {
@@ -33,7 +33,7 @@ namespace AspNetBundling
 
             // Generates source map using an approach documented here: http://ajaxmin.codeplex.com/discussions/446616
             var sourcePath = VirtualPathUtility.ToAbsolute(bundle.Path);
-            var mapVirtualPath = string.Concat(bundle.Path, "map"); // don't use .map so it's picked up by the bundle module
+            var mapVirtualPath = string.Concat(bundle.Path, sourceMapExtension);
             var mapPath = VirtualPathUtility.ToAbsolute(mapVirtualPath);
 
             // Concatenate file contents to be minified, including the sourcemap hints
@@ -86,18 +86,18 @@ namespace AspNetBundling
             {
                 // only Trace the fact that an exception occurred to the Warning output, but use Informational tracing for added detail for diagnosis
                 Trace.TraceWarning("An exception occurred trying to build bundle contents for bundle with virtual path: " + bundle.Path + ". See Exception details in Information.");
-                
+
                 string bundlePrefix = "[Bundle '" + bundle.Path + "']";
                 Trace.TraceInformation(bundlePrefix + " exception message: " + ex.Message);
-                
+
                 if (ex.InnerException != null && !string.IsNullOrEmpty(ex.InnerException.Message))
                 {
                     Trace.TraceInformation(bundlePrefix + " inner exception message: " + ex.InnerException.Message);
                 }
-                
+
                 Trace.TraceInformation(bundlePrefix + " source: " + ex.Source);
                 Trace.TraceInformation(bundlePrefix + " stack trace: " + ex.StackTrace);
-                
+
                 return GenerateGenericErrorsContent(contentConcatedString);
             }
         }
@@ -141,7 +141,7 @@ namespace AspNetBundling
                 {
                     // Write the transformed contents to another Bundle
                     var fileVirtualPath = file.IncludedVirtualPath;
-                    var virtualPathTransformed = "~/" + Path.ChangeExtension(fileVirtualPath, string.Concat(".transformed",  Path.GetExtension(fileVirtualPath)));
+                    var virtualPathTransformed = "~/" + Path.ChangeExtension(fileVirtualPath, string.Concat(".transformed", Path.GetExtension(fileVirtualPath)));
                     AddContentToAdHocBundle(context, virtualPathTransformed, contents);
                 }
 
@@ -190,5 +190,7 @@ namespace AspNetBundling
         internal bool minifyCode = false;
 
         internal bool preserveImportantComments = true;
+
+        internal string sourceMapExtension = ScriptWithSourceMapBundle.DefaultSourceMapExtension;
     }
 }


### PR DESCRIPTION
Some tools like [Bugsnag](https://www.bugsnag.com/) require custom extension for the source maps to work. This adds the ability to define them, you just need to add handler to your web.config for it to work. See [https://stackoverflow.com/a/12931522](https://stackoverflow.com/a/12931522).


```
<handlers>
    <!-- ... -->
    <add name="scriptBundle" verb="*" path="script.js" type="System.Web.Optimization.BundleHandler, System.Web.Optimization" preCondition="managedHandler" />
    <add name="cssBundle" verb="*" path="style.css" type="System.Web.Optimization.BundleHandler, System.Web.Optimization" preCondition="managedHandler" />
</handlers>
```

This adds the ability to define your custom source map extension.